### PR TITLE
Corrected URL in Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you're in a Ruby shop, you'll want these:
 
 If you're in a Python shop, you'll want these:
 
-* [Learn Python the Hard Way] (https://github.com/discoposse/sysadmin-reading-list.git)
+* [Learn Python the Hard Way] (http://learnpythonthehardway.org/book/)
 
 ## Tools
 


### PR DESCRIPTION
I had accidentally pasted the repo URL instead of the book URL.