### PR TITLE
Deal with GitHub stargazers fuckery

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,10 +12,11 @@ This repository is copyright 2017-2023 Joseph Block under a [Attribution-NonComm
 # Types of changes
 <!--- What types of changes does your PR introduce? Put an `x` in all the boxes that apply: -->
 
-- [ ] New entry
 - [ ] Link updates
-- [ ] Typo cleanup
+- [ ] New entry
+- [ ] Test updates
 - [ ] Text updates
+- [ ] Typo cleanup
 
 # Checklist:
 

--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -17,4 +17,4 @@ jobs:
     - uses: actions/checkout@v7
     - uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/README.md README.md --allow-timeout --request-delay 1 --allow 202,206,403,418,429,500,502,503,504,509,521 --allow-ssl --allow-redirect --allow-dupe -w www.terraform.io,signup.hangops.com,kitchen.ci --white-list https://vimeo.com,kubernetes.io,kitchen.ci,debuggex.com,smile.amazon.com,code.visualstudio.com
+        args: /github/workspace/README.md README.md --allow-timeout --request-delay 1 --allow 202,206,403,418,429,500,502,503,504,509,521 --allow-ssl --allow-redirect --allow-dupe -w www.terraform.io,signup.hangops.com,kitchen.ci --white-list https://vimeo.com,kubernetes.io,kitchen.ci,debuggex.com,smile.amazon.com,code.visualstudio.com,https://github.com/unixorn/sysadmin-reading-list/stargazers


### PR DESCRIPTION
# Description

GitHub is 404ing stargazers links when called by the awesomebot action, but they work just fine in a browser.

Add https://github.com/unixorn/sysadmin-reading-list/stargazers to awesomebot allowlist

# License Assignment

This repository is copyright 2017-2023 Joseph Block under a [Attribution-NonCommercial-ShareAlike 4.0 International](#attribution-noncommercial-sharealike-40-international) license.

- [x] I assign copyright to the changes in this PR to Joseph Block per the [Attribution-NonCommercial-ShareAlike 4.0 International](#attribution-noncommercial-sharealike-40-international) license.

# Types of changes
<!--- What types of changes does your PR introduce? Put an `x` in all the boxes that apply: -->

- [ ] New entry
- [ ] Link updates
- [ ] Typo cleanup
- [ ] Text updates
- [x] Test updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in a comment on the PR -->

- [x] All new and existing tests pass.
- [ ] List entries are sorted alphabetically.
- [ ] Any list entries are one line. This makes it easier to keep the sections sorted. Let the markdown renderer handle line breaks, don't try to help it.
- [ ] I confirmed that all the links in my PR are valid.
